### PR TITLE
Require ivar/ivars to be a symmetric address

### DIFF
--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -18,7 +18,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivar}{Local address of a remotely accessible data object.
+  \apiargument{IN}{ivar}{Symmetric address of a remotely accessible data object.
     The type of \VAR{ivar} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{cmp}{The comparison operator that compares \VAR{ivar} with
     \VAR{cmp\_value}.}

--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -19,7 +19,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_test_all_vector.tex
+++ b/content/shmem_test_all_vector.tex
@@ -21,7 +21,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_test_any.tex
+++ b/content/shmem_test_any.tex
@@ -20,7 +20,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_test_any_vector.tex
+++ b/content/shmem_test_any_vector.tex
@@ -21,7 +21,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_test_some.tex
+++ b/content/shmem_test_some.tex
@@ -20,7 +20,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_test_some_vector.tex
+++ b/content/shmem_test_some_vector.tex
@@ -21,7 +21,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -29,7 +29,7 @@ Table~\ref{p2psynctypes}.
 
 \begin{apiarguments}
 
-\apiargument{IN}{ivar}{Local address of a remotely accessible data object.
+\apiargument{IN}{ivar}{Symmetric address of a remotely accessible data object.
     The type of \VAR{ivar} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{cmp}{The compare operator that compares \VAR{ivar} with
     \VAR{cmp\_value}.}

--- a/content/shmem_wait_until_all.tex
+++ b/content/shmem_wait_until_all.tex
@@ -19,7 +19,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until_all_vector.tex
+++ b/content/shmem_wait_until_all_vector.tex
@@ -20,7 +20,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until_any.tex
+++ b/content/shmem_wait_until_any.tex
@@ -20,7 +20,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until_any_vector.tex
+++ b/content/shmem_wait_until_any_vector.tex
@@ -21,7 +21,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until_some.tex
+++ b/content/shmem_wait_until_some.tex
@@ -20,7 +20,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}

--- a/content/shmem_wait_until_some_vector.tex
+++ b/content/shmem_wait_until_some_vector.tex
@@ -21,7 +21,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ivars}{Local address of an array of remotely accessible data
+  \apiargument{IN}{ivars}{Symmetric address of an array of remotely accessible data
     objects.
     The type of \VAR{ivars} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{The number of elements in the \VAR{ivars} array.}


### PR DESCRIPTION
Require ivar/ivars in `shmem_{wait_until*, test*}` to be a symmetric address

Closes https://github.com/openshmem-org/specification/issues/393