### PR TITLE
Specify deprecated p2p types for `shmem_wait_until` and `shmem_test`

### DIFF
--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -8,9 +8,9 @@
 int @\FuncDecl{shmem\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes} and
+Table \ref{stdamotypes}
 \begin{DeprecateBlock}
-where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
 point-to-point synchronization types
 specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
@@ -19,9 +19,9 @@ specified by Table~\ref{p2psynctypes}.
 int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table~\ref{stdamotypes} and
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}
 \begin{DeprecateBlock}
-where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
 point-to-point synchronization types and has a
 corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -8,13 +8,23 @@
 int @\FuncDecl{shmem\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes}.
+Table \ref{stdamotypes} and
+\begin{DeprecateBlock}
+where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+point-to-point synchronization types
+specified by Table~\ref{p2psynctypes}.
+\end{DeprecateBlock}
 
 \begin{Csynopsis}
 int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes} and
+\begin{DeprecateBlock}
+where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+point-to-point synchronization types and has a
+corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+\end{DeprecateBlock}
 
 \begin{apiarguments}
 

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -10,8 +10,8 @@ int @\FuncDecl{shmem\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 where \TYPE{} is one of the standard \ac{AMO} types specified by
 Table \ref{stdamotypes},
 \begin{DeprecateBlock}
-or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
-has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{Csynopsis}

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -8,22 +8,20 @@
 int @\FuncDecl{shmem\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes}
+Table \ref{stdamotypes},
 \begin{DeprecateBlock}
-and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
-point-to-point synchronization types
-specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
+has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{Csynopsis}
 int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_test}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes},
 \begin{DeprecateBlock}
-and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
-point-to-point synchronization types and has a
-corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
+has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{apiarguments}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -8,9 +8,9 @@
 void @\FuncDecl{shmem\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes} and
+Table \ref{stdamotypes}
 \begin{DeprecateBlock}
-where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
 point-to-point synchronization types
 specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
@@ -19,9 +19,9 @@ specified by Table~\ref{p2psynctypes}.
 void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table~\ref{stdamotypes} and
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}
 \begin{DeprecateBlock}
-where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
 point-to-point synchronization types and has a
 corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -8,13 +8,23 @@
 void @\FuncDecl{shmem\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes}.
+Table \ref{stdamotypes} and
+\begin{DeprecateBlock}
+where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+point-to-point synchronization types
+specified by Table~\ref{p2psynctypes}.
+\end{DeprecateBlock}
 
 \begin{Csynopsis}
 void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes} and
+\begin{DeprecateBlock}
+where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+point-to-point synchronization types and has a
+corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+\end{DeprecateBlock}
 
 \begin{DeprecateBlock}
 \begin{CsynopsisCol}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -8,22 +8,20 @@
 void @\FuncDecl{shmem\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{AMO} types specified by
-Table \ref{stdamotypes}
+Table \ref{stdamotypes},
 \begin{DeprecateBlock}
-and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
-point-to-point synchronization types
-specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
+has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{Csynopsis}
 void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{AMO} types and has a
-corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}
+corresponding \TYPENAME{} specified by Table~\ref{stdamotypes},
 \begin{DeprecateBlock}
-and where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
-point-to-point synchronization types and has a
-corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
+has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{DeprecateBlock}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -10,8 +10,8 @@ void @\FuncDecl{shmem\_wait\_until}@(TYPE *ivar, int cmp, TYPE cmp_value);
 where \TYPE{} is one of the standard \ac{AMO} types specified by
 Table \ref{stdamotypes},
 \begin{DeprecateBlock}
-or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\} and
-has a corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+or \TYPE{} is one of \{\CTYPE{short}, \CTYPE{unsigned short}\}
+specified by Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
 
 \begin{Csynopsis}


### PR DESCRIPTION
Addendum to https://github.com/naveen-rn/specification/pull/3, cc https://github.com/openshmem-org/specification/issues/334

This PR specifies the deprecated `short` and `unsigned short` types from
the p2p sync types table to the C11 and C/C++ function synopses of
`shmem_wait_until` and `shmem_test`.

Otherwise, the specification for these these functions would only be
found in the deprecation table.

For the descriptions, I chose to go with directly specifying `short` and `unsigned short` as the difference between the two tables rather than specifying both tables as before and forcing the user to figure out what the difference is.