### PR TITLE
Revert backmatter changes from naveen-rn/specification#3

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -343,20 +343,6 @@ supported before removal.
     \hyperref[subsec:shmem_alltoall]{\FUNC{shmem\_alltoall}} \\ \hline
     \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
-    \minitab{\Cstd[11]: \FuncRef{shmem\_wait\_until(\CTYPE{short} ...)}
-        \\ \CorCpp: \FuncRef{shmem\_short\_wait\_until}}
-        & 1.5 & Current & (none) \\ \hline
-    \minitab{\Cstd[11]: \FuncRef{shmem\_wait\_until(\CTYPE{unsigned short} ...)}
-        \\ \CorCpp: \FuncRef{shmem\_ushort\_wait\_until}}
-        & 1.5 & Current & (none) \\ \hline
-    \minitab{\Cstd[11]: \FuncRef{shmem\_test(\CTYPE{short} ...)}
-        \\ \CorCpp: \FuncRef{shmem\_short\_test}}
-        & 1.5 & Current & (none) \\ \hline
-    \minitab{\Cstd[11]: \FuncRef{shmem\_test(\CTYPE{unsigned short} ...)}
-        \\ \CorCpp: \FuncRef{shmem\_ushort\_test}}
-        & 1.5 & Current & (none) \\ \hline
-    \minitab{Table~\ref{p2psynctypes}: point-to-point synchronization types}
-        & 1.5 & Current & Table~\ref{stdamotypes}: standard AMO types \\ \hline
     \end{longtable}
 \end{center}
 
@@ -523,18 +509,6 @@ for that particular team. Rather than continue to support \FUNC{shmem\_barrier}
 for active-sets or teams, programs should use a call to \FUNC{shmem\_quiet}
 followed by a call to \FUNC{shmem\_sync} in order to explicitly
 indicate which context to quiesce.
-
-\subsection{\textit{C11} and \CorCpp: \FUNC{shmem\_wait\_until} and \FUNC{shmem\_test} --- \CTYPE{short} and \CTYPE{unsigned short} variants}
-The \CTYPE{short} and \CTYPE{unsigned short} type \CorCpp and \textit{C11}
-routines for \FUNC{shmem\_wait\_until} and \FUNC{shmem\_test} were deprecated
-because point-to-point synchronization routines are only compatible with
-\acp{AMO} (as of \openshmem 1.5), and there is no corresponding AMO for
-\CTYPE{short} and \CTYPE{unsigned short}.
-
-\subsection{Table~\ref{p2psynctypes}: point-to-point synchronization types}
-As of \openshmem 1.5, the point-to-point synchronization routines are only
-compatible with \acp{AMO}, so their interfaces are defined via the
-standard \ac{AMO} types in Table~\ref{stdamotypes}.
 
 \chapter{Changes to this Document}\label{sec:changelog}
 


### PR DESCRIPTION
cc naveen-rn/specification#3

Move these changes to BryantLam/openshmem-specification#18

--

Revert "Add deprecation rationale for p2psynch types table"

This reverts commit 238d7003f22a83ea4a470a1b80df48f08725d7a1.

Revert "Reorder short/ushort p2psync deprecation rationale"

This reverts commit 22f89a4a8e660c9a268b61cd926907f1905c1f79.

Revert backmatter.tex changes from 4cc60ba76369f910638076ba1195ae1bf5b4f8ee as represented in commit cedbe5a2ab7ff58af33825c250d5fe46c3424618.