### PR TITLE
Fix issue #413: define behavior for nonzero status values

### DIFF
--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -50,8 +50,8 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
     the element is excluded from the test set.  Elements of \VAR{status} set to
-    0 will be included in the test set, and elements set to 1 will be ignored.  If all elements
-    in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is empty
+    0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all elements
+    in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is empty
     and this routine returns 0.  If \VAR{status} is a null pointer, it is
     ignored and all elements in \VAR{ivars} are included in the test set.  The
     \VAR{ivars}, \VAR{indices}, and \VAR{status} arrays must not overlap in

--- a/content/shmem_test_all_vector.tex
+++ b/content/shmem_test_all_vector.tex
@@ -52,8 +52,8 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
     the element is excluded from the test set.  Elements of \VAR{status} set to
-    0 will be included in the test set, and elements set to 1 will be ignored.  If all elements
-    in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is empty
+    0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all elements
+    in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is empty
     and this routine returns 0.  If \VAR{status} is a null pointer, it is
     ignored and all elements in \VAR{ivars} are included in the test set.  The
     \VAR{ivars}, \VAR{indices}, and \VAR{status} arrays must not overlap in

--- a/content/shmem_test_any.tex
+++ b/content/shmem_test_any.tex
@@ -53,8 +53,8 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
     the element is excluded from the test set.  Elements of
-    \VAR{status} set to 0 will be included in the test set, and elements set to 1 will be ignored.  If all
-    elements in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is
+    \VAR{status} set to 0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all
+    elements in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is
     empty and this routine returns \CONST{SIZE\_MAX}.  If \VAR{status} is a
     null pointer, it is ignored and all
     elements in \VAR{ivars} are included in the test set.  The \VAR{ivars} and

--- a/content/shmem_test_any_vector.tex
+++ b/content/shmem_test_any_vector.tex
@@ -55,7 +55,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the test set.  Elements of
     \VAR{status} set to 0 will be included in the test set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the test set is empty and this routine returns
     \CONST{SIZE\_MAX}.  If \VAR{status} is a null pointer, it is ignored and
     all elements in \VAR{ivars} are included in the test set.  The \VAR{ivars}

--- a/content/shmem_test_some.tex
+++ b/content/shmem_test_some.tex
@@ -70,8 +70,8 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
     the element is excluded from the test set.  Elements of \VAR{status} set to
-    0 will be included in the test set, and elements set to 1 will be ignored.  If all
-    elements in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is
+    0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all
+    elements in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is
     empty and this routine returns 0.  If \VAR{status} is a null pointer, it is ignored and all
     elements in \VAR{ivars} are included in the test set.  The \VAR{ivars},
     \VAR{indices}, and \VAR{status} arrays must not overlap in memory.

--- a/content/shmem_test_some_vector.tex
+++ b/content/shmem_test_some_vector.tex
@@ -67,8 +67,8 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether
     the element is excluded from the test set.  Elements of \VAR{status} set to
-    0 will be included in the test set, and elements set to 1 will be ignored.  If all
-    elements in \VAR{status} are set to 1 or \VAR{nelems} is 0, the test set is
+    0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all
+    elements in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is
     empty and this routine returns 0.  If \VAR{status} is a null pointer, it is ignored and all
     elements in \VAR{ivars} are included in the test set.  The \VAR{ivars},
     \VAR{indices}, and \VAR{status} arrays must not overlap in memory.

--- a/content/shmem_wait_until_all.tex
+++ b/content/shmem_wait_until_all.tex
@@ -52,7 +52,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns
     immediately.  If \VAR{status} is a null pointer, it is ignored and
     all elements in \VAR{ivars} are included in the wait set.  The \VAR{ivars}

--- a/content/shmem_wait_until_all_vector.tex
+++ b/content/shmem_wait_until_all_vector.tex
@@ -50,7 +50,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns
     immediately.  If \VAR{status} is a null pointer, it is ignored and all
     elements in \VAR{ivars} are included in the wait set.  The \VAR{ivars} and

--- a/content/shmem_wait_until_any.tex
+++ b/content/shmem_wait_until_any.tex
@@ -52,7 +52,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns
     \CONST{SIZE\_MAX}.  If
     \VAR{status} is a null pointer, it is ignored and all elements in

--- a/content/shmem_wait_until_any_vector.tex
+++ b/content/shmem_wait_until_any_vector.tex
@@ -53,7 +53,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns
     \CONST{SIZE\_MAX}.  If \VAR{status} is a null pointer, it is ignored and
     all elements in \VAR{ivars} are included in the wait set.  The \VAR{ivars}

--- a/content/shmem_wait_until_some.tex
+++ b/content/shmem_wait_until_some.tex
@@ -68,7 +68,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns 0.
     If \VAR{status} is a null pointer, it is ignored
     and all elements in \VAR{ivars} are included in the wait set.  The

--- a/content/shmem_wait_until_some_vector.tex
+++ b/content/shmem_wait_until_some_vector.tex
@@ -68,7 +68,7 @@ corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     element corresponds to the respective element in \VAR{ivars} and indicates
     whether the element is excluded from the wait set.  Elements of
     \VAR{status} set to 0 will be included in the wait set, and elements set to
-    1 will be ignored.  If all elements in \VAR{status} are set to 1 or
+    a nonzero value will be ignored.  If all elements in \VAR{status} are nonzero or
     \VAR{nelems} is 0, the wait set is empty and this routine returns 0.
     If \VAR{status} is a null pointer, it is ignored
     and all elements in \VAR{ivars} are included in the wait set.  The


### PR DESCRIPTION
This PR addresses issue https://github.com/openshmem-org/specification/issues/413 by defining the behavior of all nonzero values in the `status` array of the point-to-point synchronization routines.

Please review @nspark @naveen-rn @BryantLam - and @jamesaross may also want to have a look.